### PR TITLE
Changes the signature of intercept to return the Throwable.

### DIFF
--- a/shared/src/main/scala/verify/Assertion.scala
+++ b/shared/src/main/scala/verify/Assertion.scala
@@ -20,7 +20,7 @@ trait Assertion extends asserts.AssertEquals[Unit] {
   override protected def stringAssertEqualsListener = PowerAssert.stringAssertEqualsListener
   lazy val assert: PowerAssert = new PowerAssert()
 
-  def intercept[E <: Throwable: ClassTag](callback: => Unit)(implicit pos: SourceLocation): Unit = {
+  def intercept[E <: Throwable: ClassTag](callback: => Unit)(implicit pos: SourceLocation): Throwable = {
 
     val E = implicitly[ClassTag[E]]
     try {
@@ -31,7 +31,7 @@ trait Assertion extends asserts.AssertEquals[Unit] {
       case ex: InterceptException =>
         throw new AssertionError(ex.getMessage)
       case ex: Throwable if E.runtimeClass.isInstance(ex) =>
-        () // Do nothing!
+         ex
     }
   }
 

--- a/shared/src/test/scala/example/tests/SimpleTest.scala
+++ b/shared/src/test/scala/example/tests/SimpleTest.scala
@@ -55,15 +55,17 @@ object SimpleTest extends BasicTestSuite {
     intercept[AssertionError] {
       assert(s == "dummy")
     }
+    ()
   }
 
   test("intercept") {
-    class DummyException extends RuntimeException
+    class DummyException(message: String) extends RuntimeException(message)
     def test = 1
 
-    intercept[DummyException] {
-      if (test != 2) throw new DummyException
+    val ex = intercept[DummyException] {
+      if (test != 2) throw new DummyException("value was different to 2")
     }
+    assertEquals("value was different to 2", ex.getMessage)
   }
 
   testAsync("asynchronous test") {
@@ -83,11 +85,13 @@ object SimpleTest extends BasicTestSuite {
         if (hello(1) != 2) throw new DummyException
       }
     }
+    ()
   }
 
   test("fail()") {
     def x = 1
     intercept[AssertionError] { if (x == 1) fail() }
+    ()
   }
 
   test("fail(reason)") {


### PR DESCRIPTION
Returning the exception that was intercepted allows the library users to inspect the exception a little bit more, so they don't have to rely on just the expected type and can compare, as an example, the error message.

Would you prefer to have this new signature as a new function for compat issues maybe?