### PR TITLE
Add scala-native 0.4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
             sudo apt install clang libunwind-dev libgc-dev libre2-dev
             sbt ++$SCALA211! verifyNative/test
             env SCALANATIVE_VERSION="0.4.0-M2" sbt ++$SCALA211! verifyNative/test
+            env SCALANATIVE_VERSION="0.4.0" sbt +verifyNative/test
             ;;
           *)
             echo unknown jobtype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
             sudo apt-get update
             sudo apt install clang libunwind-dev libgc-dev libre2-dev
             sbt ++$SCALA211! verifyNative/test
-            env SCALANATIVE_VERSION="0.4.0-M2" sbt ++$SCALA211! verifyNative/test
-            env SCALANATIVE_VERSION="0.4.0" sbt +verifyNative/test
+            env SCALANATIVE_VERSION="0.4.0-M2" sbt ++$SCALA211! verifyNative/clean verifyNative/test
+            env SCALANATIVE_VERSION="0.4.0" sbt +verifyNative/clean +verifyNative/test
             ;;
           *)
             echo unknown jobtype

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ Verify
 
 Verify is a minimalist unit testing framework, tracing its origins to [Minitest](https://github.com/monix/minitest) + [Expecty](https://github.com/eed3si9n/expecty) + [SourceCode](https://github.com/lihaoyi/sourcecode).
 
-It is a a small testing framework cross-compiled for Scala 2.11, 2.12, 2.13, Scala 3.x, [Scala.js](http://www.scala-js.org/) 0.6 and 1.0, and
-[Scala Native 0.3.x](https://www.scala-native.org/).
+It is a small testing framework cross-compiled for Scala 2.11, 2.12, 2.13, Scala 3.x, [Scala.js](http://www.scala-js.org/) 0.6 and 1.0, and
+[Scala Native](https://www.scala-native.org/) 0.3.x and 0.4.0.
 
 ## Usage in sbt
 
-For `build.sbt` (use the `%%%` operator for Scala.js):
+For `build.sbt` (use the `%%%` operator for Scala.js or Scala Native):
 
 ```scala
-// use the %%% operator for Scala.js
+// use the %%% operator for Scala.js or Scala Native
 libraryDependencies += "com.eed3si9n.verify" %% "verify" % "1.0.0" % Test
 
 testFrameworks += new TestFramework("verify.runner.Framework")

--- a/native/src/main/scala/verify/platform/package.scala
+++ b/native/src/main/scala/verify/platform/package.scala
@@ -12,15 +12,23 @@
 
 package verify
 
-import scala.scalanative.testinterface.PreloadedClassLoader
+import com.github.ghik.silencer.silent
+import org.scalajs.testinterface.TestUtils
 import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 package object platform {
   val defaultExecutionContext: ExecutionContext = ExecutionContext.global
 
+  // Deprecated in 0.4.0, required for 0.3.9 support
+  @silent("deprecated") 
   type EnableReflectiveInstantiation =
     scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 
+  // Deprecated in 0.4.0, required for 0.3.9 support
+  // Unfortunately, the TestUtils semantics changed from 0.3.9 to 0.4.0, so we need to try both names
+  @silent("deprecated") 
   private[verify] def loadModule(name: String, loader: ClassLoader): Any =
-    loader.asInstanceOf[PreloadedClassLoader].loadPreloaded(name)
+    Try(TestUtils.loadModule(name, loader)).getOrElse(TestUtils.loadModule(name + "$", loader))
+    
 }

--- a/shared/src/main/scala-2/verify/sourcecode/Macros.scala
+++ b/shared/src/main/scala-2/verify/sourcecode/Macros.scala
@@ -196,6 +196,8 @@ object Macros {
           case x if x.isTerm && x.asTerm.isVar     => Chunk.Var
           case x if x.isTerm && x.asTerm.isLazy    => Chunk.Lzy
           case x if x.isTerm && x.asTerm.isVal     => Chunk.Val
+          case _                                   =>
+            throw new Exception("Unexpected chunk symbol:" + current) 
         }
 
         path = chunk(Util.getName(c)(current)) :: path

--- a/shared/src/test/scala/example/asserttest/RenderingTest.scala
+++ b/shared/src/test/scala/example/asserttest/RenderingTest.scala
@@ -30,56 +30,44 @@ object RenderingTest extends BasicTestSuite {
   }
 
   test("List.apply") {
-    if (isScala3) {
-      outputs("""assertion failed
-
-List() == List(1, 2)
-|      |  |
-List() |  List(1, 2)
-       false
-    """) {
-        assert {
-          List() == List(1, 2)
-        }
-      }
-    } else {
-      outputs("""assertion failed
+    val oldStr = """assertion failed
 
 List() == List(1, 2)
        |  |
        |  List(1, 2)
        false
-    """) {
-        assert {
-          List() == List(1, 2)
-        }
+    """
+    val newStr = """assertion failed
+
+List() == List(1, 2)
+|      |  |
+List() |  List(1, 2)
+       false
+    """
+    outputs(oldStr, newStr) {
+      assert {
+        List() == List(1, 2)
       }
     }
   }
 
   test("List.apply2") {
-    if (isScala3) {
-      outputs("""assertion failed
+    val oldStr = """assertion failed
+
+List(1, 2) == List()
+|          |
+List(1, 2) false
+    """
+    val newStr = """assertion failed
 
 List(1, 2) == List()
 |          |  |
 List(1, 2) |  List()
            false
-    """) {
-        assert {
-          List(1, 2) == List()
-        }
-      }
-    } else {
-      outputs("""assertion failed
-
-List(1, 2) == List()
-|          |
-List(1, 2) false
-    """) {
-        assert {
-          List(1, 2) == List()
-        }
+    """
+    outputs(oldStr, newStr) {
+      assert {
+        List(1, 2) == List()
       }
     }
   }
@@ -399,7 +387,7 @@ and corrigible authority of this lies in our wills.                          |  
     }
   }
 
-  def outputs(rendering: String)(expectation: => Unit): Unit = {
+  def outputs(renderings: String*)(expectation: => Unit): Unit = {
     def normalize(s: String) = augmentString(s.trim()).linesIterator.toList.mkString
 
     try {
@@ -407,13 +395,13 @@ and corrigible authority of this lies in our wills.                          |  
       fail("Expectation should have failed but didn't")
     } catch {
       case e: AssertionError => {
-        val expected = normalize(rendering)
+        val expected = renderings.map(normalize)
         val actual = normalize(e.getMessage)
           .replaceAll("@[0-9a-f]*", "@\\.\\.\\.")
           .replaceAll("\u001b\\[[\\d;]*[^\\d;]", "")
-        if (actual != expected) {
+        if (!expected.contains(actual)) {
           throw new AssertionError(s"""Expectation output doesn't match: ${e.getMessage}
-               |expected = $expected
+               |${expected.map(s => "expected = " + s).mkString("\n")}
                |actual   = $actual
                |""".stripMargin)
         }


### PR DESCRIPTION
Adds scala-native 0.4.0 support, which [should be released soon](https://github.com/scala-native/scala-native/issues/2043#issuecomment-758992830).

I had to add some hacks to keep the 0.3.9/0.4.0-M2 support. If you decide to drop support for those versions in the future, the code can be cleaned up.